### PR TITLE
Update Ipopt to 0.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,5 @@
 name = "EAGO"
 uuid = "bb8be931-2a91-5aca-9f87-79e1cb69959a"
-
 authors = ["Matthew Wilhelm <matthew.wilhelm@uconn.edu>"]
 version = "0.6.1"
 
@@ -33,7 +32,7 @@ ForwardDiff = "~0.5.0, ~0.6, ~0.7, ~0.8, ~0.9, ~0.10"
 GLPK = "~0.9, ~0.10, ~0.11, ~0.12, ~0.13"
 IntervalArithmetic = "~0.14, ~0.15, ~0.16, ~0.17"
 IntervalContractors = "~0.3, ~0.4"
-Ipopt = "~0.6"
+Ipopt = "~0.7"
 JuMP = "0.21.2, 0.21.3, 0.21.4, 0.21.5, 0.21.6"
 MathOptInterface = "0.9.13, 0.9.14, 0.9.15, 0.9.16, 0.9.17, 0.9.18, 0.9.19"
 McCormick = "0.11.0"
@@ -42,7 +41,6 @@ NumericIO = "= 0.3.1"
 Reexport = "~0.2"
 SpecialFunctions = "~0.8, ~0.9, ~0.10"
 julia = "~1"
-
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
This is important for me (and potentially others as well) because Ipopt 0.6 is unstable and causes crashes in my environment (WSL Ubuntu 20.04).

Confirmed to pass the test.