### PR TITLE
remove upper bound for julia version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EAGO"
 uuid = "bb8be931-2a91-5aca-9f87-79e1cb69959a"
 authors = ["Matthew Wilhelm <matthew.wilhelm@uconn.edu>"]
-version = "0.7.1"
+version = "0.7.2"
 
 [deps]
 Cassette = "7057c7e9-c182-5462-911a-8362d720325c"
@@ -45,7 +45,7 @@ PrettyTables = "~1"
 Reexport = "~0.2, ~1"
 Requires = "~1"
 SpecialFunctions = "~1, ~2"
-julia = "1.6 - 1.8"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
The previous compat bound excluded Julia 1.8.1, so if you try to install EAGO you actually get a much older version. I also don't really see the point in capping the Julia version like this since Julia adheres to semver.