### PR TITLE
Refactor of JuMP's nonlinear API

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -12,8 +12,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          # Build documentation on Julia 1.3
-          version: '1.5'
+          # Build documentation on Julia 1.6
+          version: '1.6'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EAGO"
 uuid = "bb8be931-2a91-5aca-9f87-79e1cb69959a"
 authors = ["Matthew Wilhelm <matthew.wilhelm@uconn.edu>"]
-version = "0.7.3"
+version = "0.8.0"
 
 [deps]
 Cassette = "7057c7e9-c182-5462-911a-8362d720325c"
@@ -36,7 +36,7 @@ ForwardDiff = "~0.10"
 IntervalArithmetic = "~0.20"
 IntervalContractors = "~0.4"
 Ipopt = "~1"
-JuMP = "1.0.0 - 1.1.1"
+JuMP = "1.11"
 MINLPTests = "0.5.2"
 MathOptInterface = "~1"
 McCormick = "0.13"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -10,4 +10,4 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 Documenter = "^0.26"
-JuMP = "1.0.0 - 1.1.1"
+JuMP = "1.11"

--- a/src/EAGO.jl
+++ b/src/EAGO.jl
@@ -13,19 +13,14 @@ __precompile__()
 
 module EAGO
 
+    using MathOptInterface
     import MathOptInterface
-
+    import MathOptInterface.Nonlinear: DEFAULT_MULTIVARIATE_OPERATORS, DEFAULT_UNIVARIATE_OPERATORS
     using Reexport, Requires, Cassette, IntervalArithmetic, DocStringExtensions,
           FastRounding, SpecialFunctions, Ipopt, Cbc, Printf, PrettyTables
 
     using JuMP
     import JuMP
-    import JuMP._Derivatives: operators, NodeData
-    using JuMP._Derivatives: univariate_operators,
-                             univariate_operator_to_id
-    import JuMP: _SubexpressionStorage
-    import JuMP._Derivatives: NodeType, UserOperatorRegistry
-    const JuMPOpReg = JuMP._Derivatives.UserOperatorRegistry
 
     using DataStructures: OrderedDict, BinaryMinMaxHeap, popmin!, popmax!, top
     using SparseArrays: SparseMatrixCSC, spzeros, rowvals, nzrange, nonzeros, sparse, findnz
@@ -54,6 +49,8 @@ module EAGO
     const MOI = MathOptInterface
     const MOIU = MOI.Utilities
     const MOIB = MOI.Bridges
+    const MOINL = MOI.Nonlinear
+    const MOIRAD = MOINL.ReverseAD
 
     const SAF = MOI.ScalarAffineFunction{Float64}
     const SQF = MOI.ScalarQuadraticFunction{Float64}

--- a/src/eago_optimizer/functions/nonlinear/auxiliary_variables.jl
+++ b/src/eago_optimizer/functions/nonlinear/auxiliary_variables.jl
@@ -1,7 +1,7 @@
 
 function _not_EAGO_error!(m::JuMP.Model)
     if JuMP.solver_name(m) !== "EAGO: Easy Advanced Global Optimization"
-        error("Solve attached to model must be EAGO.Optimizer")
+        error("Solver attached to model must be EAGO.Optimizer")
     end
 end
 

--- a/src/eago_optimizer/functions/nonlinear/composite_relax/forward_propagation.jl
+++ b/src/eago_optimizer/functions/nonlinear/composite_relax/forward_propagation.jl
@@ -313,10 +313,10 @@ function fprop!(t::Relax, v::Val{USERN}, g::DAT, b::RelaxCache{V,N,T}, k::Int) w
         i += 1
     end
     if anysets
-        z = MOI.eval_objective(mv, set_input)::MC{N,T}
+        z = mv.f(set_input)::MC{N,T}
         b[k] = cut(z, set(b, k), b.ic.v, zero(Float64), sparsity(g,k), b.cut, b.post)
     else
-        b[k] = MOI.eval_objective(mv, num_input)
+        b[k] = mv.f(num_input)
     end
 end
 

--- a/src/eago_optimizer/functions/nonlinear/graph/graph.jl
+++ b/src/eago_optimizer/functions/nonlinear/graph/graph.jl
@@ -20,27 +20,43 @@ function _variable_count(g::AbstractDG)::Int
     error("Variable count not defined for graph type = $(typeof(g))")
 end
 
-# added id field from JuMP UserOperatorRegistry, expect more extensive changes in future.
+# added id field to MOI OperatorRegistry
 struct OperatorRegistry
-    multivariate_id::Vector{Symbol}
-    multivariate_operator_to_id::Dict{Symbol,Int}
-    multivariate_operator_evaluator::Vector{MOI.AbstractNLPEvaluator}
+    univariate_operators::Vector{Symbol}
     univariate_operator_id::Vector{Symbol}
     univariate_operator_to_id::Dict{Symbol,Int}
-    univariate_operator_f::Vector{Any}
-    univariate_operator_fprime::Vector{Any}
-    univariate_operator_fprimeprime::Vector{Any}
+    univariate_user_operator_start::Int
+    registered_univariate_operators::Vector{MOINL._UnivariateOperator}
+    multivariate_operators::Vector{Symbol}
+    multivariate_id::Vector{Symbol}
+    multivariate_operator_to_id::Dict{Symbol,Int}
+    multivariate_user_operator_start::Int
+    registered_multivariate_operators::Vector{MOINL._MultivariateOperator}
+    logic_operators::Vector{Symbol}
+    logic_operator_id::Vector{Symbol}
+    logic_operator_to_id::Dict{Symbol,Int}
+    comparison_operators::Vector{Symbol}
+    comparison_operator_id::Vector{Symbol}
+    comparison_operator_to_id::Dict{Symbol,Int}
 end
 function OperatorRegistry()
     return OperatorRegistry(
         Symbol[],
-        Dict{Symbol,Int}(),
-        MOI.AbstractNLPEvaluator[],
         Symbol[],
         Dict{Symbol,Int}(),
-        [],
-        [],
-        [],
+        0,
+        MOINL._UnivariateOperator[],
+        Symbol[],
+        Symbol[],
+        Dict{Symbol,Int}(),
+        0,
+        MOINL._MultivariateOperator[],
+        Symbol[],
+        Symbol[],
+        Dict{Symbol,Int}(),
+        Symbol[],
+        Symbol[],
+        Dict{Symbol,Int}()
     )
 end
 

--- a/src/eago_optimizer/functions/nonlinear/graph/graphs/directed_tree.jl
+++ b/src/eago_optimizer/functions/nonlinear/graph/graphs/directed_tree.jl
@@ -224,12 +224,12 @@ dep_subexpr_count(g::DAT)                = length(g.dependent_subexpressions)
 sparsity(g::DAT, i)                      = g.sparsity
 rev_sparsity(g::DAT, i::Int, k::Int)     = g.rev_sparsity[i]
 
-user_univariate_operator(g::DAT, i) = g.user_operators.univariate_operator_f[i]
-user_multivariate_operator(g::DAT, i) = g.user_operators.multivariate_operator_evaluator[i]
+user_univariate_operator(g::DAT, i) = g.user_operators.registered_univariate_operators[i].f
+user_multivariate_operator(g::DAT, i) = g.user_operators.registered_multivariate_operators[i]
 
 function DirectedTree(aux_info, d, op::OperatorRegistry, sub_sparsity::Dict{Int,Vector{Int}}, subexpr_linearity, parameter_values, is_sub, subexpr_indx)
-
-    nd = copy(d.nd)
+    
+    nd = copy(d.nodes)
     adj = copy(d.adj)
     const_values = copy(d.const_values)
 
@@ -243,7 +243,7 @@ function DirectedTree(aux_info, d, op::OperatorRegistry, sub_sparsity::Dict{Int,
         rev_sparsity[s] = i
     end
 
-    nodes = _convert_node_list(aux_info, d.nd, op)
+    nodes = _convert_node_list(aux_info, d.nodes, op)
     lin = linearity(nd, adj, subexpr_linearity)
     DirectedTree(nodes = nodes,
                     variables = rev_sparsity,

--- a/src/eago_optimizer/functions/nonlinear/graph/utilities.jl
+++ b/src/eago_optimizer/functions/nonlinear/graph/utilities.jl
@@ -16,23 +16,24 @@ function binary_switch(ids; is_forward = true)
     end
 end
 
-function Node(aux_info, d::JuMP._Derivatives.NodeData, child_vec, c::UnitRange{Int}, op)
-    nt = d.nodetype
+function Node(aux_info, d::MOINL.Node, child_vec, c::UnitRange{Int}, op)
+    nt = d.type
     i = d.index
-    (nt == JuMP._Derivatives.CALL)          && return _create_call_node(i, child_vec, c, op)
-    (nt == JuMP._Derivatives.CALLUNIVAR)    && return _create_call_node_uni(i, child_vec, c, op)
-    (nt == JuMP._Derivatives.VALUE)         && return Node(Constant(), i)
-    (nt == JuMP._Derivatives.PARAMETER)     && return Node(Parameter(), i)
-    (nt == JuMP._Derivatives.SUBEXPRESSION) && return Node(Subexpression(), i)
-    (nt == JuMP._Derivatives.VARIABLE)      && return !is_auxiliary_variable(aux_info, i) ? Node(Variable(), i) : Node(Select(), i)
-    (nt == JuMP._Derivatives.LOGIC)         && error("Unable to load JuMP expression. Logical operators not currently supported.")
-    (nt == JuMP._Derivatives.COMPARISON)    && error("Unable to load JuMP expression. Comparisons not currently supported.")
+    (nt == MOINL.NODE_CALL_MULTIVARIATE)    && return _create_call_node(i, child_vec, c, op)
+    (nt == MOINL.NODE_CALL_UNIVARIATE)      && return _create_call_node_uni(i, child_vec, c, op)
+    (nt == MOINL.NODE_VALUE)                && return Node(Constant(), i)
+    (nt == MOINL.NODE_PARAMETER)            && return Node(Parameter(), i)
+    (nt == MOINL.NODE_SUBEXPRESSION)        && return Node(Subexpression(), i)
+    (nt == MOINL.NODE_VARIABLE)             && return !is_auxiliary_variable(aux_info, i) ? Node(Variable(), i) : Node(Select(), i)
+    (nt == MOINL.NODE_MOI_VARIABLE)         && return !is_auxiliary_variable(aux_info, i) ? Node(Variable(), i) : Node(Select(), i)
+    (nt == MOINL.NODE_LOGIC)                && error("Unable to load JuMP expression. Logical operators not currently supported.")
+    (nt == MOINL.NODE_COMPARISON)           && error("Unable to load JuMP expression. Comparisons not currently supported.")
     error("Node type = $nt not expected from JuMP.")
 end
 
-function _convert_node_list(aux_info, x::Vector{JuMP._Derivatives.NodeData}, op)
+function _convert_node_list(aux_info, x::Vector{MOINL.Node}, op)
     y = Vector{Node}(undef, length(x))
-    adj = JuMP._Derivatives.adjmat(x)
+    adj = MOINL.adjacency_matrix(x)
     child_vec = rowvals(adj)
     for i in eachindex(x)
         y[i] = Node(aux_info, x[i], child_vec, nzrange(adj, i), op)
@@ -40,21 +41,21 @@ function _convert_node_list(aux_info, x::Vector{JuMP._Derivatives.NodeData}, op)
     return y
 end
 
-# Access gradient sparsity of JuMP storage.
-sparsity(d::JuMP._FunctionStorage) = d.grad_sparsity
-sparsity(d::JuMP._SubexpressionStorage) = d.sparsity
+# Access gradient sparsity of MOI storage.
+sparsity(d::MOIRAD._FunctionStorage) = d.grad_sparsity
+#sparsity(d::MOIRAD._SubexpressionStorage) = d.sparsity
 
-# Compute gradient sparsity from JuMP storage.
-function _compute_sparsity(d::JuMP._FunctionStorage, sparse_dict::Dict{Int,Vector{Int}}, is_sub, subexpr_indx)
+# Compute gradient sparsity from MOI storage.
+function _compute_sparsity(d::MOIRAD._FunctionStorage, sparse_dict::Dict{Int,Vector{Int}}, is_sub, subexpr_indx)
     dep_subexpression = Int[]
     variable_dict = Dict{Int,Bool}()
-    for n in d.nd
-        if n.nodetype == JuMP._Derivatives.VARIABLE
+    for n in d.nodes
+        if n.type == MOINL.NODE_VARIABLE
             if !haskey(variable_dict, n.index)
                 variable_dict[n.index] = true
             end
         end
-        if n.nodetype == JuMP._Derivatives.SUBEXPRESSION
+        if n.type == MOINL.NODE_SUBEXPRESSION
             push!(dep_subexpression, n.index)
         end
     end
@@ -71,16 +72,16 @@ function _compute_sparsity(d::JuMP._FunctionStorage, sparse_dict::Dict{Int,Vecto
     end
     sparsity, dep_subexpression
 end
-function _compute_sparsity(d::JuMP._SubexpressionStorage, sparse_dict::Dict{Int,Vector{Int}}, is_sub, subexpr_indx)
+function _compute_sparsity(d::MOIRAD._SubexpressionStorage, sparse_dict::Dict{Int,Vector{Int}}, is_sub, subexpr_indx)
     dep_subexpression = Int[]
     variable_dict = Dict{Int,Bool}()
-    for n in d.nd
-        if n.nodetype == JuMP._Derivatives.VARIABLE
+    for n in d.nodes
+        if n.type == MOINL.NODE_VARIABLE
             if !haskey(variable_dict, n.index)
                 variable_dict[n.index] = true
             end
         end
-        if n.nodetype == JuMP._Derivatives.SUBEXPRESSION
+        if n.type == MOINL.NODE_SUBEXPRESSION
             push!(dep_subexpression, n.index)
         end
     end
@@ -98,25 +99,34 @@ function _compute_sparsity(d::JuMP._SubexpressionStorage, sparse_dict::Dict{Int,
     sparsity, dep_subexpression
 end
 
-function linearity(d::JuMP._Derivatives.Linearity)
-    (d == JuMP._Derivatives.LINEAR)            && return LIN_LINEAR
-    (d == JuMP._Derivatives.PIECEWISE_LINEAR)  && return LIN_PIECEWISE_LINEAR
-    (d == JuMP._Derivatives.NONLINEAR)         && return LIN_NONLINEAR
-    LIN_CONSTANT                               # assumes d is then JuMP._Derivatives.CONSTANT
+function linearity(d::MOIRAD.Linearity)
+    (d == MOIRAD.LINEAR)            && return LIN_LINEAR
+    (d == MOIRAD.PIECEWISE_LINEAR)  && return LIN_PIECEWISE_LINEAR
+    (d == MOIRAD.NONLINEAR)         && return LIN_NONLINEAR
+    LIN_CONSTANT                   # assumes d is then MOINL.CONSTANT
 end
-function linearity(nd::Vector{JuMP._Derivatives.NodeData}, adj::SparseMatrixCSC{Bool,Int}, d::Vector{JuMP._Derivatives.Linearity})
-    x = JuMP._Derivatives.classify_linearity(nd, adj, d)
+
+function linearity(nd::Vector{MOINL.Node}, adj::SparseMatrixCSC{Bool,Int}, d::Vector{MOIRAD.Linearity})
+    x = MOIRAD._classify_linearity(nd, adj, d)
     linearity.(x)
 end
 
-function OperatorRegistry(d::JuMP._Derivatives.UserOperatorRegistry)
-    mv_id = collect(keys(d.multivariate_operator_to_id))
-    mv_operator_to_id = d.multivariate_operator_to_id
-    mv_operator_evaluator = d.multivariate_operator_evaluator
+function OperatorRegistry(d::MOINL.OperatorRegistry)
+    u_operators = d.univariate_operators
     u_operator_id = collect(keys(d.univariate_operator_to_id))
     u_to_id = d.univariate_operator_to_id
-    u_to_f = d.univariate_operator_f
-    u_fprime = d.univariate_operator_fprime
-    u_fprimeprime = d.univariate_operator_fprimeprime
-    OperatorRegistry(mv_id, mv_operator_to_id, mv_operator_evaluator, u_operator_id, u_to_id, u_to_f, u_fprime, u_fprimeprime)
+    u_operator_start = d.univariate_user_operator_start
+    r_u_operators = d.registered_univariate_operators
+    mv_operators = d.multivariate_operators
+    mv_operator_id = collect(keys(d.multivariate_operator_to_id))
+    mv_to_id = d.multivariate_operator_to_id
+    mv_operator_start = d.multivariate_user_operator_start
+    r_mv_operators = d.registered_multivariate_operators
+    l_operators = d.logic_operators
+    l_operator_id = collect(keys(d.logic_operator_to_id))
+    l_to_id = d.logic_operator_to_id
+    c_operators = d.comparison_operators
+    c_operator_id = collect(keys(d.comparison_operator_to_id))
+    c_to_id = d.comparison_operator_to_id
+    OperatorRegistry(u_operators, u_operator_id, u_to_id, u_operator_start, r_u_operators, mv_operators, mv_operator_id, mv_to_id, mv_operator_start, r_mv_operators, l_operators, l_operator_id, l_to_id, c_operators, c_operator_id, c_to_id)
 end

--- a/src/eago_optimizer/functions/nonlinear/nonlinear.jl
+++ b/src/eago_optimizer/functions/nonlinear/nonlinear.jl
@@ -45,10 +45,10 @@ function NonlinearExpression()
 end
 
 relax_info(s::Relax, n::Int, t::T) where T = MC{n,T}
-function NonlinearExpression!(aux_info, rtype::S, sub::Union{JuMP._SubexpressionStorage,JuMP._FunctionStorage},
+function NonlinearExpression!(aux_info, rtype::S, sub::Union{MOIRAD._SubexpressionStorage,MOIRAD._FunctionStorage},
                               b::MOI.NLPBoundsPair, sub_sparsity::Dict{Int,Vector{Int}},
                               subexpr_indx::Int,
-                              subexpr_linearity::Vector{JuMP._Derivatives.Linearity},
+                              subexpr_linearity::Vector{MOIRAD.Linearity},
                               op::OperatorRegistry, parameter_values,
                               tag::T, use_apriori_flag::Bool; is_sub::Bool = false) where {S,T}
     g = DirectedTree(aux_info, sub, op, sub_sparsity, subexpr_linearity, parameter_values, is_sub, subexpr_indx)
@@ -97,9 +97,9 @@ function BufferedNonlinearFunction()
     return BufferedNonlinearFunction{MC{1,NS},1,NS}(ex, saf)
 end
 
-function BufferedNonlinearFunction(aux_info, rtype::RELAX_ATTRIBUTE, f::JuMP._FunctionStorage, b::MOI.NLPBoundsPair,
+function BufferedNonlinearFunction(aux_info, rtype::RELAX_ATTRIBUTE, f::MOIRAD._FunctionStorage, b::MOI.NLPBoundsPair,
                                    sub_sparsity::Dict{Int,Vector{Int}},
-                                   subexpr_lin::Vector{JuMP._Derivatives.Linearity},
+                                   subexpr_lin::Vector{MOIRAD.Linearity},
                                    op::OperatorRegistry, parameter_values,
                                    tag::T, use_apriori_flag::Bool) where T <: RelaxTag
 
@@ -265,17 +265,17 @@ function eliminate_fixed_variables!(f::NonlinearExpression{V,N,T}, v::Vector{Var
     indx_to_const_loc = Dict{Int,Int}()
     for i = 1:length(expr.nd)
         nd = @inbounds expr.nd[i]
-        if nd.nodetype === JuMP._Derivatives.VARIABLE
+        if nd.type === MOINL.NODE_VARIABLE
             indx = nd.index
             if v[indx].is_fixed
                 if haskey(indx_to_const_loc, indx)
                     const_loc = indx_to_const_loc[indx]
-                    expr.nd[i] = NodeData(JuMP._Derivatives.VALUE, const_loc, nd.parent)
+                    expr.nd[i] = MOINL.Node(MOINL.NODE_VALUE, const_loc, nd.parent)
                 else
                     push!(const_values, v[indx].lower_bound)
                     num_constants += 1
                     indx_to_const_loc[indx] = num_constants
-                    expr.nd[i] = NodeData(nd.nodetype, num_constants, nd.parent)
+                    expr.nd[i] = MOINL.Node(nd.type, num_constants, nd.parent)
                 end
                 f.isnumber[i] = true
             end

--- a/src/eago_optimizer/functions/nonlinear/register_special.jl
+++ b/src/eago_optimizer/functions/nonlinear/register_special.jl
@@ -33,14 +33,10 @@ function register_eago_operators!(m::JuMP.Model)
     JuMP.register(m, :xabsx, 1, xabsx, McCormick.xabsx_deriv, McCormick.xabsx_deriv2)
     JuMP.register(m, :logcosh, 1, xabsx, McCormick.xabsx_deriv, McCormick.xabsx_deriv2)
 
-    # register activatio functions w/ parameters
-    d_param_relu = JuMP._UserFunctionEvaluator(x -> param_relu(x...),
-                                               (g,x) -> McCormick.param_relu_grad(g,x...), 2)
-    d_elu = JuMP._UserFunctionEvaluator(x -> elu(x...), (g,x) -> McCormick.elu_grad(g,x...), 2)
-    d_selu = JuMP._UserFunctionEvaluator(x -> selu(x...), (g,x) -> McCormick.selu_grad(g,x...), 3)
-    JuMP._Derivatives.register_multivariate_operator!(m.nlp_data.user_operators, :param_relu, d_param_relu)
-    JuMP._Derivatives.register_multivariate_operator!(m.nlp_data.user_operators, :elu, d_elu)
-    JuMP._Derivatives.register_multivariate_operator!(m.nlp_data.user_operators, :selu, d_selu)
+    # register activation functions w/ parameters
+    MOINL.register_operator(m, :param_relu, 2, param_relu, McCormick.param_relu_grad)
+    MOINL.register_operator(m, :elu, 2, elu, McCormick.elu_grad)
+    MOINL.register_operator(m, :selu, 3, selu, McCormick.selu_grad)
 
     # register other functions
     JuMP.register(m, :xlogx, 1, xlogx, McCormick.xlogx_deriv, McCormick.xlogx_deriv2)
@@ -49,22 +45,15 @@ function register_eago_operators!(m::JuMP.Model)
     JuMP.register(m, :f_erfc, 1, x -> erfc(x), McCormick.erfc_deriv, McCormick.erfc_deriv2)
     JuMP.register(m, :f_erfcinv, 1, x -> erfcinv(x), x -> -McCormick.erfinv_deriv(1.0 - x), x -> McCormick.erfinv_deriv2(1.0 - x))
 
-    d_arh = JuMP._UserFunctionEvaluator(x -> McCormick.arh(x...), (g,x) -> McCormick.arh_grad(g,x...), 2)
-    d_xexpax = JuMP._UserFunctionEvaluator(x -> McCormick.xexpax(x...), (g,x) -> McCormick.xexpax_grad(g,x...), 2)
-    JuMP._Derivatives.register_multivariate_operator!(m.nlp_data.user_operators, :arh, d_arh)
-    JuMP._Derivatives.register_multivariate_operator!(m.nlp_data.user_operators, :xexpax, d_xexpax)
+    MOINL.register_operator(m, :arh, 2, arh, McCormick.arh_grad)
+    MOINL.register_operator(m, :xexpax, 2, xexpax, McCormick.xexpax_grad)
 
     # register bounding functions
-    d_lower_bnd = JuMP._UserFunctionEvaluator(x -> lower_bnd(x...), (g,x) -> McCormick.d_lower_bnd_grad(g,x...), 2)
-    d_upper_bnd = JuMP._UserFunctionEvaluator(x -> upper_bnd(x...), (g,x) -> McCormick.d_upper_bnd_grad(g,x...), 2)
-    d_bnd = JuMP._UserFunctionEvaluator(x -> bnd(x...), (g,x) -> McCormick.d_bnd_grad(g,x...), 3)
-    JuMP._Derivatives.register_multivariate_operator!(m.nlp_data.user_operators, :lower_bnd, d_lower_bnd)
-    JuMP._Derivatives.register_multivariate_operator!(m.nlp_data.user_operators, :upper_bnd, d_upper_bnd)
-    JuMP._Derivatives.register_multivariate_operator!(m.nlp_data.user_operators, :bnd, d_bnd)
+    MOINL.register_operator(m, :lower_bnd, 2, lower_bnd, McCormick.lower_bnd_grad)
+    MOINL.register_operator(m, :upper_bnd, 2, upper_bnd, McCormick.upper_bnd_grad)
+    MOINL.register_operator(m, :bnd, 3, bnd, McCormick.bnd_grad)
     JuMP.register(m, :positive, 1, positive, x -> 1.0, x -> 0.0)
     JuMP.register(m, :negative, 1, negative, x -> 1.0, x -> 0.0)
-
-    m.nlp_data.largest_user_input_dimension = 3
 
     return nothing
 end

--- a/src/eago_optimizer/functions/nonlinear/register_special.jl
+++ b/src/eago_optimizer/functions/nonlinear/register_special.jl
@@ -34,9 +34,9 @@ function register_eago_operators!(m::JuMP.Model)
     JuMP.register(m, :logcosh, 1, xabsx, McCormick.xabsx_deriv, McCormick.xabsx_deriv2)
 
     # register activation functions w/ parameters
-    MOINL.register_operator(m, :param_relu, 2, param_relu, McCormick.param_relu_grad)
-    MOINL.register_operator(m, :elu, 2, elu, McCormick.elu_grad)
-    MOINL.register_operator(m, :selu, 3, selu, McCormick.selu_grad)
+    MOINL.register_operator(m.nlp_model, :param_relu, 2, param_relu, McCormick.param_relu_grad)
+    MOINL.register_operator(m.nlp_model, :elu, 2, elu, McCormick.elu_grad)
+    MOINL.register_operator(m.nlp_model, :selu, 3, selu, McCormick.selu_grad)
 
     # register other functions
     JuMP.register(m, :xlogx, 1, xlogx, McCormick.xlogx_deriv, McCormick.xlogx_deriv2)
@@ -45,13 +45,13 @@ function register_eago_operators!(m::JuMP.Model)
     JuMP.register(m, :f_erfc, 1, x -> erfc(x), McCormick.erfc_deriv, McCormick.erfc_deriv2)
     JuMP.register(m, :f_erfcinv, 1, x -> erfcinv(x), x -> -McCormick.erfinv_deriv(1.0 - x), x -> McCormick.erfinv_deriv2(1.0 - x))
 
-    MOINL.register_operator(m, :arh, 2, arh, McCormick.arh_grad)
-    MOINL.register_operator(m, :xexpax, 2, xexpax, McCormick.xexpax_grad)
+    MOINL.register_operator(m.nlp_model, :arh, 2, arh, McCormick.arh_grad)
+    MOINL.register_operator(m.nlp_model, :xexpax, 2, xexpax, McCormick.xexpax_grad)
 
     # register bounding functions
-    MOINL.register_operator(m, :lower_bnd, 2, lower_bnd, McCormick.lower_bnd_grad)
-    MOINL.register_operator(m, :upper_bnd, 2, upper_bnd, McCormick.upper_bnd_grad)
-    MOINL.register_operator(m, :bnd, 3, bnd, McCormick.bnd_grad)
+    MOINL.register_operator(m.nlp_model, :lower_bnd, 2, lower_bnd, McCormick.d_lower_bnd_grad)
+    MOINL.register_operator(m.nlp_model, :upper_bnd, 2, upper_bnd, McCormick.d_upper_bnd_grad)
+    MOINL.register_operator(m.nlp_model, :bnd, 3, bnd, McCormick.d_bnd_grad)
     JuMP.register(m, :positive, 1, positive, x -> 1.0, x -> 0.0)
     JuMP.register(m, :negative, 1, negative, x -> 1.0, x -> 0.0)
 

--- a/src/eago_optimizer/optimize/optimize_convex.jl
+++ b/src/eago_optimizer/optimize/optimize_convex.jl
@@ -155,7 +155,7 @@ end
 
 """
 
-Constructs and solves the problem locally on on node `y` updated the upper
+Constructs and solves the problem locally on node `y` updated the upper
 solution informaton in the optimizer.
 """
 function solve_local_nlp!(m::GlobalOptimizer{R,S,Q}) where {R,S,Q<:ExtensionType}

--- a/src/eago_script/script.jl
+++ b/src/eago_script/script.jl
@@ -11,16 +11,13 @@
 
 module Script
 
+    import MathOptInterface
+    import MathOptInterface.Nonlinear: DEFAULT_MULTIVARIATE_OPERATORS, DEFAULT_UNIVARIATE_OPERATORS
     using MathOptInterface: AbstractOptimizer, features_available, initialize, NLPBlockData
+    const MOINL = MathOptInterface.Nonlinear
     using SparseArrays: rowvals, nzrange, SparseMatrixCSC, spzeros
     import Base: afoldl, getindex, iterate
-    import JuMP: _NLPData, _NonlinearExprData, NLPEvaluator
-    import JuMP._Derivatives: univariate_operator_to_id, operator_to_id,
-                              comparison_operator_to_id, CALL, CALLUNIVAR,
-                              COMPARISON, VARIABLE, MOIVARIABLE, VALUE,
-                              SUBEXPRESSION, PARAMETER, NodeType, NodeData,
-                              USER_OPERATOR_ID_START, USER_UNIVAR_OPERATOR_ID_START,
-                              UserOperatorRegistry, adjmat
+    import JuMP: NLPEvaluator
     import Cassette: @context, Cassette.overdub, Cassette.prehook
     import Cassette
     #import CodeTransformation: addmethod! TODO: add this later

--- a/src/eago_script/scrubber.jl
+++ b/src/eago_script/scrubber.jl
@@ -79,12 +79,12 @@ function scrub(f::Function, n::Int, inplace = false)
 end
 
 """
-    scrub!(d::_NLPData)
+    scrub!(d::MOI.NLPBlockData)
 
-Applies scrub to every user-defined function in the a `_NLPData` structure.
+Applies scrub to every user-defined function in the a `MOI.NLPBlockData` structure.
 """
-function scrub!(d::_NLPData)
-
+function scrub!(d::MOI.NLPBlockData)
+    error("Function not updated for newest version of EAGO. Please submit an issue.")
     # scrub multivariant
     user_ops = d.user_operators
     mvop_num = length(user_ops.multivariate_operator_evaluator)

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -6,7 +6,7 @@ function _precompile_()
     Base.precompile(Tuple{Type{Optimizer}})   # time: 0.5019401
     Base.precompile(Tuple{typeof(MathOptInterface.empty!),Optimizer{Incremental{GLPK.Optimizer}, Incremental{Ipopt.Optimizer}, DefaultExt}})   # time: 0.0625456
     Base.precompile(Tuple{typeof(initialize!),RelaxCache{1, NS},DirectedTree})   # time: 0.0522575
-    Base.precompile(Tuple{Type{BufferedNonlinearFunction},JuMP._FunctionStorage,MathOptInterface.NLPBoundsPair,Dict{Int64, Vector{Int64}},Vector{JuMP._Derivatives.Linearity},OperatorRegistry,Vector{Float64},NS})   # time: 0.030106
+    Base.precompile(Tuple{Type{BufferedNonlinearFunction},MOIRAD._FunctionStorage,MathOptInterface.NLPBoundsPair,Dict{Int64, Vector{Int64}},Vector{MOIRAD.Linearity},OperatorRegistry,Vector{Float64},NS})   # time: 0.030106
     Base.precompile(Tuple{typeof(MathOptInterface.is_empty),Optimizer{Incremental{GLPK.Optimizer}, Incremental{Ipopt.Optimizer}, DefaultExt}})   # time: 0.0280181
     Base.precompile(Tuple{typeof(initialize!),RelaxCache{2, NS},DirectedTree})   # time: 0.0236066
     Base.precompile(Tuple{typeof(_propagate_constraint!),Evaluator,BufferedNonlinearFunction{1, NS}})   # time: 0.0191075

--- a/test/branch_bound.jl
+++ b/test/branch_bound.jl
@@ -15,10 +15,10 @@
 
     EAGO.node_selection!(x)
     @test isapprox(x._current_node.lower_variable_bounds[1], 1.0; atol = 1E-4)
-    @test isapprox(x._current_node.upper_variable_bounds[1], 1.475; atol = 1E-2)
+    @test isapprox(x._current_node.upper_variable_bounds[1], 1.425; atol = 1E-2)
 
     EAGO.node_selection!(x)
-    @test isapprox(x._current_node.lower_variable_bounds[1], 1.475; atol = 1E-2)
+    @test isapprox(x._current_node.lower_variable_bounds[1], 1.425; atol = 1E-2)
     @test isapprox(x._current_node.upper_variable_bounds[1], 2.0; atol = 1E-4)
 
     x._global_upper_bound = -4.5

--- a/test/moit_tests.jl
+++ b/test/moit_tests.jl
@@ -103,7 +103,13 @@ function test_runtests()
                                 "test_cpsat_CountAtLeast",
                                 "test_cpsat_Table",
                                 "test_linear_Semicontinuous_integration",
-                                "test_linear_Semiinteger_integration"
+                                "test_linear_Semiinteger_integration",
+
+                                # Remove these tests after MOI 1.17.2
+                                "test_objective_ObjectiveSense_in_ListOfModelAttributesSet",
+                                "test_objective_ScalarAffineFunction_in_ListOfModelAttributesSet",
+                                "test_objective_ScalarQuadraticFunction_in_ListOfModelAttributesSet",
+                                "test_objective_VariableIndex_in_ListOfModelAttributesSet"
 
                                 ],
                       exclude_tests_after = v"0.10.5")

--- a/test/moit_tests.jl
+++ b/test/moit_tests.jl
@@ -103,13 +103,7 @@ function test_runtests()
                                 "test_cpsat_CountAtLeast",
                                 "test_cpsat_Table",
                                 "test_linear_Semicontinuous_integration",
-                                "test_linear_Semiinteger_integration",
-
-                                # MOI model attribute exclusions
-                                "test_objective_ObjectiveSense_in_ListOfModelAttributesSet",
-                                "test_objective_ScalarAffineFunction_in_ListOfModelAttributesSet",
-                                "test_objective_ScalarQuadraticFunction_in_ListOfModelAttributesSet",
-                                "test_objective_VariableIndex_in_ListOfModelAttributesSet"
+                                "test_linear_Semiinteger_integration"
 
                                 ],
                       exclude_tests_after = v"0.10.5")

--- a/test/moit_tests.jl
+++ b/test/moit_tests.jl
@@ -14,7 +14,7 @@ const CONFIG = MOI.Test.Config(atol = 1e-3, rtol = 1e-3, optimal_status = MOI.OP
 """
     runtests()
 
-This function runs all functions in the this Module starting with `test_`.
+This function runs all functions in this Module starting with `test_`.
 """
 function runtests()
     for name in names(@__MODULE__; all = true)
@@ -96,7 +96,20 @@ function test_runtests()
                                 "test_objective_qp_ObjectiveFunction_zero_ofdiag",
 
                                 "test_model_ModelFilter_ListOfConstraintIndices",
-                                "test_model_ModelFilter_ListOfConstraintTypesPresent"
+                                "test_model_ModelFilter_ListOfConstraintTypesPresent",
+
+                                # MOI constraint type exclusions
+                                "test_cpsat_Circuit",
+                                "test_cpsat_CountAtLeast",
+                                "test_cpsat_Table",
+                                "test_linear_Semicontinuous_integration",
+                                "test_linear_Semiinteger_integration",
+
+                                # MOI model attribute exclusions
+                                "test_objective_ObjectiveSense_in_ListOfModelAttributesSet",
+                                "test_objective_ScalarAffineFunction_in_ListOfModelAttributesSet",
+                                "test_objective_ScalarQuadraticFunction_in_ListOfModelAttributesSet",
+                                "test_objective_VariableIndex_in_ListOfModelAttributesSet"
 
                                 ],
                       exclude_tests_after = v"0.10.5")

--- a/test/optimizer.jl
+++ b/test/optimizer.jl
@@ -256,7 +256,7 @@ end
     @test new_node.upper_bound == 0.0
 
     @test_nowarn EAGO.single_storage!(m)
-    @test_nowarn EAGO.optimize_hook!(EAGO.DefaultExt(), m)
+    @test_nowarn EAGO.optimize_hook!(EAGO.DefaultExt(), x)
 end
 #=
 @testset "Fallback Interval Bounds" begin
@@ -640,7 +640,7 @@ end
 
     @NLconstraint(model, c9, softsign(x) <= 0.0)
     @NLconstraint(model, c10, gelu(x) <= 0.0)
-    @NLconstraint(model, c11, swish1(x) <= 0.0)
+    @NLconstraint(model, c11, swish(x) <= 0.0)
 
     @NLconstraint(model, c12, positive(x) <= 0.0)
     @NLconstraint(model, c13, negative(x) <= 0.0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ const MOI = MathOptInterface
 const MOIT = MOI.Test
 const MOIU = MOI.Utilities
 const MOIB = MOI.Bridges
+const MOINL = MOI.Nonlinear
 
 println("CHECK REVISED TESTS")
 

--- a/test/script_optimizer.jl
+++ b/test/script_optimizer.jl
@@ -1,6 +1,6 @@
-function check_node(nd::EAGO.Script.NodeInfo, type::MOINL.Node , indx::Int, child::Vector{Int})
+function check_node(nd::EAGO.Script.NodeInfo, type::MOINL.NodeType , indx::Int, child::Vector{Int})
     flag = true
-    if nd.type != type
+    if nd.nodetype != type
         flag = false
         return flag
     end

--- a/test/script_optimizer.jl
+++ b/test/script_optimizer.jl
@@ -1,6 +1,6 @@
-function check_node(nd::EAGO.Script.NodeInfo, type::JuMP._Derivatives.NodeType , indx::Int, child::Vector{Int})
+function check_node(nd::EAGO.Script.NodeInfo, type::MOINL.Node , indx::Int, child::Vector{Int})
     flag = true
-    if nd.nodetype != type
+    if nd.type != type
         flag = false
         return flag
     end
@@ -22,12 +22,12 @@ end
         return sin(3.0*x[1]) + x[2]
     end
     tape1 = EAGO.Script.trace_script(f1,2)
-    @test check_node(tape1.nd[1], JuMP._Derivatives.VARIABLE, 1, [-1])
-    @test check_node(tape1.nd[2], JuMP._Derivatives.VARIABLE, 2, [-1])
-    @test check_node(tape1.nd[3], JuMP._Derivatives.VALUE, 1, [-2])
-    @test check_node(tape1.nd[4], JuMP._Derivatives.CALL, 3, [3,1])
-    @test check_node(tape1.nd[5], JuMP._Derivatives.CALLUNIVAR, 15, [4])
-    @test check_node(tape1.nd[6], JuMP._Derivatives.CALL, 1, [5,2])
+    @test check_node(tape1.nd[1], MOINL.NODE_VARIABLE, 1, [-1])
+    @test check_node(tape1.nd[2], MOINL.NODE_VARIABLE, 2, [-1])
+    @test check_node(tape1.nd[3], MOINL.NODE_VALUE, 1, [-2])
+    @test check_node(tape1.nd[4], MOINL.NODE_CALL_MULTIVARIATE, 3, [3,1])
+    @test check_node(tape1.nd[5], MOINL.NODE_CALL_UNIVARIATE, 15, [4])
+    @test check_node(tape1.nd[6], MOINL.NODE_CALL_MULTIVARIATE, 1, [5,2])
     @test tape1.const_values[1] == 3.0
     @test tape1.num_valued[1] == false
     @test tape1.num_valued[2] == false
@@ -47,20 +47,20 @@ end
         return sin(3.0*x[2]) + y
     end
     tape2 = EAGO.Script.trace_script(f2,2)
-    @test check_node(tape2.nd[1], JuMP._Derivatives.VARIABLE, 1, [-1])
-    @test check_node(tape2.nd[2], JuMP._Derivatives.VARIABLE, 2, [-1])
-    @test check_node(tape2.nd[3], JuMP._Derivatives.CALLUNIVAR, 3, [1])
-    @test check_node(tape2.nd[4], JuMP._Derivatives.VALUE, 1, [-2])
-    @test check_node(tape2.nd[5], JuMP._Derivatives.CALL, 3, [4,3])
-    @test check_node(tape2.nd[6], JuMP._Derivatives.VALUE, 2, [-2])
-    @test check_node(tape2.nd[7], JuMP._Derivatives.CALL, 1, [6,5])
-    @test check_node(tape2.nd[8], JuMP._Derivatives.VALUE, 3, [-2])
-    @test check_node(tape2.nd[9], JuMP._Derivatives.CALL, 3, [8,3])
-    @test check_node(tape2.nd[10], JuMP._Derivatives.CALL, 1, [7,9])
-    @test check_node(tape2.nd[11], JuMP._Derivatives.VALUE, 4, [-2])
-    @test check_node(tape2.nd[12], JuMP._Derivatives.CALL, 3, [11,2])
-    @test check_node(tape2.nd[13], JuMP._Derivatives.CALLUNIVAR, 15, [12])
-    @test check_node(tape2.nd[14], JuMP._Derivatives.CALL, 1, [13,10])
+    @test check_node(tape2.nd[1], MOINL.NODE_VARIABLE, 1, [-1])
+    @test check_node(tape2.nd[2], MOINL.NODE_VARIABLE, 2, [-1])
+    @test check_node(tape2.nd[3], MOINL.NODE_CALL_UNIVARIATE, 3, [1])
+    @test check_node(tape2.nd[4], MOINL.NODE_VALUE, 1, [-2])
+    @test check_node(tape2.nd[5], MOINL.NODE_CALL_MULTIVARIATE, 3, [4,3])
+    @test check_node(tape2.nd[6], MOINL.NODE_VALUE, 2, [-2])
+    @test check_node(tape2.nd[7], MOINL.NODE_CALL_MULTIVARIATE, 1, [6,5])
+    @test check_node(tape2.nd[8], MOINL.NODE_VALUE, 3, [-2])
+    @test check_node(tape2.nd[9], MOINL.NODE_CALL_MULTIVARIATE, 3, [8,3])
+    @test check_node(tape2.nd[10], MOINL.NODE_CALL_MULTIVARIATE, 1, [7,9])
+    @test check_node(tape2.nd[11], MOINL.NODE_VALUE, 4, [-2])
+    @test check_node(tape2.nd[12], MOINL.NODE_CALL_MULTIVARIATE, 3, [11,2])
+    @test check_node(tape2.nd[13], MOINL.NODE_CALL_UNIVARIATE, 15, [12])
+    @test check_node(tape2.nd[14], MOINL.NODE_CALL_MULTIVARIATE, 1, [13,10])
     @test tape2.const_values[1] == 1.0
     @test tape2.const_values[2] == 1.3
     @test tape2.const_values[3] == 2.0
@@ -98,8 +98,8 @@ end
     #=
     @test tape3.const_count == 0
     @test tape3.set_trace_count == 3
-    @test check_node(tape3.nd[1], JuMP._Derivatives.VARIABLE, 1, [-1])
-    @test check_node(tape3.nd[2], JuMP._Derivatives.VARIABLE, 2, [-1])
-    @test check_node(tape3.nd[3], JuMP._Derivatives.CALLUNIVAR, 3, [1])
+    @test check_node(tape3.nd[1], MOINL.NODE_VARIABLE, 1, [-1])
+    @test check_node(tape3.nd[2], MOINL.NODE_VARIABLE, 2, [-1])
+    @test check_node(tape3.nd[3], MOINL.NODE_CALL_UNIVARIATE, 3, [1])
     =#
 end


### PR DESCRIPTION
Replaced JuMP._Derivatives with MathOptInterface.Nonlinear (MOINL), updated EAGO's OperatorRegistry, modified the epigraph reformulation based on these changes, and fixed outdated tests. 