### PR TITLE
Remove inferred test for EAGO.Optimizer

### DIFF
--- a/test/optimizer.jl
+++ b/test/optimizer.jl
@@ -210,7 +210,7 @@ end
 end
 
 @testset "Set Objective" begin
-    model = @inferred EAGO.Optimizer()
+    model = EAGO.Optimizer()
 
     x = MOI.add_variables(model, 3)
 


### PR DESCRIPTION
We recently moved the MOI interface of Ipopt to a package extension (because many people wanted to use Ipopt but not MOI, and it's a fairly hefty dependency for them to carry around and compile).

The downside is that `Ipopt.Optimizer` is no longer type stable: https://github.com/jump-dev/Ipopt.jl?tab=readme-ov-file#type-stability

This shows up in your default `EAGO.Optimizer` constructor, which is now also not type stable.

We have two options:

 * Remove this test
 * Change the compat to `Ipopt = "1.10"` and use the type-stable constructor `IpoptMathOptInterfaceExt.Optimizer`.

I went for the former. I can make a PR for the latter if you'd prefer.