### PR TITLE
Use the new API to access nodes and adjacency matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,13 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
+      - name: MOI
+        shell: julia --project=@. {0}
+        run: |
+          using Pkg
+          Pkg.add([
+              PackageSpec(name="MathOptInterface", rev="bl/expression_adj"),
+          ])
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/src/eago_optimizer/functions/nonlinear/graph/graphs/directed_tree.jl
+++ b/src/eago_optimizer/functions/nonlinear/graph/graphs/directed_tree.jl
@@ -229,9 +229,9 @@ user_multivariate_operator(g::DAT, i) = g.user_operators.registered_multivariate
 
 function DirectedTree(aux_info, d, op::OperatorRegistry, sub_sparsity::Dict{Int,Vector{Int}}, subexpr_linearity, parameter_values, is_sub, subexpr_indx)
     
-    nd = copy(d.nodes)
-    adj = copy(d.adj)
-    const_values = copy(d.const_values)
+    nd = copy(MOI.Nonlinear.expression(d).nodes)
+    adj = copy(MOI.Nonlinear.adjacency_matrix(d))
+    const_values = copy(MOI.Nonlinear.expression(d).values)
 
     sparsity, dependent_subexpressions = _compute_sparsity(d, sub_sparsity, is_sub, subexpr_indx)
     dependent_subexpression_dict = Dict{Int,Int}()
@@ -243,7 +243,7 @@ function DirectedTree(aux_info, d, op::OperatorRegistry, sub_sparsity::Dict{Int,
         rev_sparsity[s] = i
     end
 
-    nodes = _convert_node_list(aux_info, d.nodes, op)
+    nodes = _convert_node_list(aux_info, MOI.Nonlinear.expression(d).nodes, op)
     lin = linearity(nd, adj, subexpr_linearity)
     DirectedTree(nodes = nodes,
                     variables = rev_sparsity,

--- a/src/eago_optimizer/functions/nonlinear/graph/utilities.jl
+++ b/src/eago_optimizer/functions/nonlinear/graph/utilities.jl
@@ -48,7 +48,7 @@ sparsity(d::MOIRAD._FunctionStorage) = d.grad_sparsity
 function _compute_sparsity(d::MOIRAD._FunctionStorage, sparse_dict::Dict{Int,Vector{Int}}, is_sub, subexpr_indx)
     dep_subexpression = Int[]
     variable_dict = Dict{Int,Bool}()
-    for n in d.nodes
+    for n in MOI.Nonlinear.expression(d).nodes
         if n.type == MOINL.NODE_VARIABLE
             if !haskey(variable_dict, n.index)
                 variable_dict[n.index] = true
@@ -74,7 +74,7 @@ end
 function _compute_sparsity(d::MOIRAD._SubexpressionStorage, sparse_dict::Dict{Int,Vector{Int}}, is_sub, subexpr_indx)
     dep_subexpression = Int[]
     variable_dict = Dict{Int,Bool}()
-    for n in d.nodes
+    for n in MOI.Nonlinear.expression(d).nodes
         if n.type == MOINL.NODE_VARIABLE
             if !haskey(variable_dict, n.index)
                 variable_dict[n.index] = true


### PR DESCRIPTION
We noticed that we broke EAGO when changing internal fields in
https://github.com/jump-dev/MathOptInterface.jl/pull/2747
Ideally, EAGO shouldn't access internal fields are they are not guaranteed to not change so https://github.com/jump-dev/MathOptInterface.jl/pull/2750 adds a public API allowing EAGO to be refactored as done in this PR to stop using internal fields.
You might also be able to refactor further to avoid using `_FunctionStorage` and `_SubexpressionStorage` in the type signatures.

Requires

- [ ] https://github.com/jump-dev/MathOptInterface.jl/pull/2750